### PR TITLE
Simple fixes on shared_ptr for better performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 project(TG_ThrowItBot)
 

--- a/src/Throw.cpp
+++ b/src/Throw.cpp
@@ -10,7 +10,7 @@ using namespace cv;
 using namespace TgBot;
 
 // ArtRobot的实际绘制函数
-shared_ptr<ArtRobot::Component::Base> drawImage(const string &__imgData)
+unique_ptr<ArtRobot::Component::Base> drawImage(const string &__imgData)
 {
     vector<unsigned char> imgVector(__imgData.begin(), __imgData.end()); // 图片转为vector
     Mat imgMat = imdecode(imgVector, IMREAD_COLOR);                      // 图片转为Mat
@@ -32,7 +32,7 @@ shared_ptr<ArtRobot::Component::Base> drawImage(const string &__imgData)
                                                             "p_mask.png",
                                                             img);
 
-    auto body = make_shared<ArtRobot::Component::Group>("body"); // body
+    auto body = make_unique<ArtRobot::Component::Group>("body"); // body
     body->addChild(bg);
     body->addChild(mask);
     return body;


### PR DESCRIPTION
Similar to the pull request not long ago for the repo SayStickerBot (https://github.com/YJBeetle/SayStickerBot/pull/2), the same problem is also found in this repo. This patch fixes the problem in the same way.

Differently, the C++ standard is increased to C++14 as only `make_unique` is used in this repo.